### PR TITLE
feat: Add UI for importing alerts from text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
       
       - name: Run linting
         run: bun run lint
-      
+        env:
+          SKIP_ENV_VALIDATION: true
+
       - name: Run type checking
         run: bun run typecheck
+        env:
+          SKIP_ENV_VALIDATION: true
       
       - name: Run tests
         run: bun run test:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,20 @@ jobs:
       - name: Run linting
         run: bun run lint
         env:
-          SKIP_ENV_VALIDATION: true
+          AUTH_SECRET: placeholder
+          AUTH_DISCORD_ID: placeholder
+          AUTH_DISCORD_SECRET: placeholder
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/crypto_fox_test
+          NEXT_PUBLIC_SOCKET_SERVER_URL: http://localhost:3001
 
       - name: Run type checking
         run: bun run typecheck
         env:
-          SKIP_ENV_VALIDATION: true
+          AUTH_SECRET: placeholder
+          AUTH_DISCORD_ID: placeholder
+          AUTH_DISCORD_SECRET: placeholder
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/crypto_fox_test
+          NEXT_PUBLIC_SOCKET_SERVER_URL: http://localhost:3001
       
       - name: Run tests
         run: bun run test:ci

--- a/src/app/alerts/components/AlertImport.tsx
+++ b/src/app/alerts/components/AlertImport.tsx
@@ -15,6 +15,8 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
   const [unparseable, setUnparseable] = useState<string[]>([]);
   const [selectedAlerts, setSelectedAlerts] = useState<Set<string>>(new Set());
   const [step, setStep] = useState<"input" | "review" | "result">("input");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const parseAlerts = api.alerts.parseAlerts.useMutation({
     onSuccess: (data) => {
@@ -26,6 +28,9 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
       );
       setStep("review");
     },
+    onError: (error) => {
+      setParseError(error.message ?? "Failed to parse alerts");
+    },
   });
 
   const bulkCreate = api.alerts.bulkCreate.useMutation({
@@ -33,11 +38,16 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
       if (result.created > 0) {
         onSuccess();
       }
+      setStep("result");
+    },
+    onError: (error) => {
+      setCreateError(error.message ?? "Failed to create alerts");
     },
   });
 
   const handleParse = () => {
     if (text.trim()) {
+      setParseError(null);
       parseAlerts.mutate({ text: text.trim() });
     }
   };
@@ -75,8 +85,8 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
       }));
 
     if (alertsToCreate.length > 0) {
+      setCreateError(null);
       bulkCreate.mutate({ alerts: alertsToCreate });
-      setStep("result");
     }
   };
 
@@ -147,6 +157,11 @@ ETHBTC 4H close above 0.04 signals rotation`}
                   <li>Shorthand: 100k = 100,000 | 94.2k = 94,200</li>
                 </ul>
               </div>
+              {parseError && (
+                <div className="rounded-lg border border-red-800/50 bg-red-900/20 p-3 text-sm text-red-400">
+                  ⚠️ {parseError}
+                </div>
+              )}
             </div>
           )}
 
@@ -258,6 +273,12 @@ ETHBTC 4H close above 0.04 signals rotation`}
                       </li>
                     ))}
                   </ul>
+                </div>
+              )}
+
+              {createError && (
+                <div className="mt-4 rounded-lg border border-red-800/50 bg-red-900/20 p-3 text-sm text-red-400">
+                  ⚠️ {createError}
                 </div>
               )}
             </div>

--- a/src/app/alerts/components/AlertImport.tsx
+++ b/src/app/alerts/components/AlertImport.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "~/trpc/react";
+import type { ParsedAlert } from "~/types/alertImport";
+
+interface AlertImportProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
+  const [text, setText] = useState("");
+  const [parsedAlerts, setParsedAlerts] = useState<ParsedAlert[]>([]);
+  const [unparseable, setUnparseable] = useState<string[]>([]);
+  const [selectedAlerts, setSelectedAlerts] = useState<Set<string>>(new Set());
+  const [step, setStep] = useState<"input" | "review" | "result">("input");
+
+  const parseAlerts = api.alerts.parseAlerts.useMutation({
+    onSuccess: (data) => {
+      setParsedAlerts(data.alerts);
+      setUnparseable(data.unparseable);
+      // Auto-select all valid alerts
+      setSelectedAlerts(
+        new Set(data.alerts.filter((a) => a.isValid).map((a) => a.id))
+      );
+      setStep("review");
+    },
+  });
+
+  const bulkCreate = api.alerts.bulkCreate.useMutation({
+    onSuccess: (result) => {
+      if (result.created > 0) {
+        onSuccess();
+      }
+    },
+  });
+
+  const handleParse = () => {
+    if (text.trim()) {
+      parseAlerts.mutate({ text: text.trim() });
+    }
+  };
+
+  const handleToggleAlert = (id: string) => {
+    setSelectedAlerts((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectAll = () => {
+    const validIds = parsedAlerts.filter((a) => a.isValid).map((a) => a.id);
+    setSelectedAlerts(new Set(validIds));
+  };
+
+  const handleSelectNone = () => {
+    setSelectedAlerts(new Set());
+  };
+
+  const handleCreate = () => {
+    const alertsToCreate = parsedAlerts
+      .filter((a) => selectedAlerts.has(a.id) && a.isValid && a.pairId !== null)
+      .map((a) => ({
+        pairId: a.pairId!,
+        type: a.type,
+        threshold: a.threshold,
+        direction: a.direction,
+        interval: a.interval,
+      }));
+
+    if (alertsToCreate.length > 0) {
+      bulkCreate.mutate({ alerts: alertsToCreate });
+      setStep("result");
+    }
+  };
+
+  const getConfidenceColor = (confidence: string) => {
+    switch (confidence) {
+      case "high":
+        return "text-green-400";
+      case "medium":
+        return "text-yellow-400";
+      case "low":
+        return "text-red-400";
+      default:
+        return "text-gray-400";
+    }
+  };
+
+  const getDirectionColor = (direction: string) => {
+    return direction === "ABOVE" ? "text-green-400" : "text-red-400";
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-gray-900 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-semibold text-white">
+            {step === "input" && "Import Alerts from Text"}
+            {step === "review" && "Review Parsed Alerts"}
+            {step === "result" && "Import Complete"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-6">
+          {step === "input" && (
+            <div className="space-y-4">
+              <p className="text-gray-300">
+                Paste your trading analysis text below. AI will extract price
+                and candle alerts automatically.
+              </p>
+              <textarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder={`Example:
+BTC 4H close ABOVE 100k confirms breakout
+ETH price touches 4000 - major resistance
+SOL BELOW 180 invalidates bullish structure
+ETHBTC 4H close above 0.04 signals rotation`}
+                className="w-full h-64 bg-gray-800 text-white rounded-lg p-4 font-mono text-sm border border-gray-700 focus:border-blue-500 focus:outline-none resize-none"
+              />
+              <div className="text-gray-500 text-sm">
+                <strong>Supported formats:</strong>
+                <ul className="list-disc ml-5 mt-1">
+                  <li>Price alerts: &quot;BTC touches 100k&quot;, &quot;ETH at 4000&quot;</li>
+                  <li>
+                    Candle alerts: &quot;4H close above&quot;, &quot;Daily close below&quot;
+                  </li>
+                  <li>Shorthand: 100k = 100,000 | 94.2k = 94,200</li>
+                </ul>
+              </div>
+            </div>
+          )}
+
+          {step === "review" && (
+            <div className="space-y-4">
+              {parsedAlerts.length > 0 && (
+                <>
+                  <div className="flex justify-between items-center">
+                    <p className="text-gray-300">
+                      Found {parsedAlerts.length} alerts.{" "}
+                      {parsedAlerts.filter((a) => a.isValid).length} valid.
+                    </p>
+                    <div className="space-x-2">
+                      <button
+                        onClick={handleSelectAll}
+                        className="text-sm text-blue-400 hover:text-blue-300"
+                      >
+                        Select All
+                      </button>
+                      <span className="text-gray-600">|</span>
+                      <button
+                        onClick={handleSelectNone}
+                        className="text-sm text-blue-400 hover:text-blue-300"
+                      >
+                        Select None
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    {parsedAlerts.map((alert) => (
+                      <div
+                        key={alert.id}
+                        className={`p-4 rounded-lg border ${
+                          alert.isValid
+                            ? selectedAlerts.has(alert.id)
+                              ? "bg-gray-800 border-blue-500"
+                              : "bg-gray-800/50 border-gray-700"
+                            : "bg-red-900/20 border-red-800/50"
+                        }`}
+                      >
+                        <div className="flex items-start gap-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedAlerts.has(alert.id)}
+                            onChange={() => handleToggleAlert(alert.id)}
+                            disabled={!alert.isValid}
+                            className="mt-1 h-5 w-5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="font-semibold text-white">
+                                {alert.pairSymbol ?? alert.coinSymbol}
+                              </span>
+                              <span
+                                className={`px-2 py-0.5 rounded text-xs font-medium ${
+                                  alert.type === "CANDLE"
+                                    ? "bg-purple-900/50 text-purple-300"
+                                    : "bg-blue-900/50 text-blue-300"
+                                }`}
+                              >
+                                {alert.type}
+                                {alert.interval && ` (${alert.interval})`}
+                              </span>
+                              <span
+                                className={`font-medium ${getDirectionColor(alert.direction)}`}
+                              >
+                                {alert.direction}
+                              </span>
+                              <span className="text-white font-mono">
+                                {parseFloat(alert.threshold).toLocaleString()}
+                              </span>
+                              <span
+                                className={`text-xs ${getConfidenceColor(alert.confidence)}`}
+                              >
+                                ({alert.confidence})
+                              </span>
+                            </div>
+                            <p className="text-gray-400 text-sm mt-1 truncate">
+                              {alert.originalText}
+                            </p>
+                            {alert.notes && (
+                              <p className="text-gray-500 text-sm mt-1">
+                                💡 {alert.notes}
+                              </p>
+                            )}
+                            {!alert.isValid && (
+                              <p className="text-red-400 text-sm mt-1">
+                                ⚠️ {alert.validationError}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+
+              {unparseable.length > 0 && (
+                <div className="mt-4 p-4 bg-yellow-900/20 border border-yellow-800/50 rounded-lg">
+                  <p className="text-yellow-400 font-medium mb-2">
+                    Could not parse ({unparseable.length}):
+                  </p>
+                  <ul className="text-gray-400 text-sm space-y-1">
+                    {unparseable.map((line, i) => (
+                      <li key={i} className="truncate">
+                        • {line}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === "result" && (
+            <div className="text-center py-8">
+              {bulkCreate.isPending ? (
+                <div className="text-gray-300">Creating alerts...</div>
+              ) : bulkCreate.data ? (
+                <div className="space-y-4">
+                  <div className="text-6xl">
+                    {bulkCreate.data.failed === 0 ? "✅" : "⚠️"}
+                  </div>
+                  <div className="text-xl text-white">
+                    Created {bulkCreate.data.created} alerts
+                    {bulkCreate.data.failed > 0 && (
+                      <span className="text-red-400">
+                        {" "}
+                        ({bulkCreate.data.failed} failed)
+                      </span>
+                    )}
+                  </div>
+                  {bulkCreate.data.errors.length > 0 && (
+                    <div className="text-red-400 text-sm mt-4">
+                      {bulkCreate.data.errors.map((err, i) => (
+                        <p key={i}>{err}</p>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-700 flex justify-end gap-3">
+          {step === "input" && (
+            <>
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-gray-300 hover:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleParse}
+                disabled={!text.trim() || parseAlerts.isPending}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {parseAlerts.isPending ? "Parsing..." : "Parse Alerts"}
+              </button>
+            </>
+          )}
+
+          {step === "review" && (
+            <>
+              <button
+                onClick={() => setStep("input")}
+                className="px-4 py-2 text-gray-300 hover:text-white"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleCreate}
+                disabled={selectedAlerts.size === 0 || bulkCreate.isPending}
+                className="px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Create {selectedAlerts.size} Alerts
+              </button>
+            </>
+          )}
+
+          {step === "result" && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg"
+            >
+              Done
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/alerts/components/AlertImport.tsx
+++ b/src/app/alerts/components/AlertImport.tsx
@@ -22,7 +22,7 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
       setUnparseable(data.unparseable);
       // Auto-select all valid alerts
       setSelectedAlerts(
-        new Set(data.alerts.filter((a) => a.isValid).map((a) => a.id))
+        new Set(data.alerts.filter((a) => a.isValid).map((a) => a.id)),
       );
       setStep("review");
     },
@@ -99,9 +99,9 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-gray-900 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-gray-900 shadow-xl">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-700 flex justify-between items-center">
+        <div className="flex items-center justify-between border-b border-gray-700 px-6 py-4">
           <h2 className="text-xl font-semibold text-white">
             {step === "input" && "Import Alerts from Text"}
             {step === "review" && "Review Parsed Alerts"}
@@ -109,7 +109,7 @@ export function AlertImport({ onClose, onSuccess }: AlertImportProps) {
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-white text-2xl leading-none"
+            className="text-2xl leading-none text-gray-400 hover:text-white"
           >
             ×
           </button>
@@ -131,14 +131,18 @@ BTC 4H close ABOVE 100k confirms breakout
 ETH price touches 4000 - major resistance
 SOL BELOW 180 invalidates bullish structure
 ETHBTC 4H close above 0.04 signals rotation`}
-                className="w-full h-64 bg-gray-800 text-white rounded-lg p-4 font-mono text-sm border border-gray-700 focus:border-blue-500 focus:outline-none resize-none"
+                className="h-64 w-full resize-none rounded-lg border border-gray-700 bg-gray-800 p-4 font-mono text-sm text-white focus:border-blue-500 focus:outline-none"
               />
-              <div className="text-gray-500 text-sm">
+              <div className="text-sm text-gray-500">
                 <strong>Supported formats:</strong>
-                <ul className="list-disc ml-5 mt-1">
-                  <li>Price alerts: &quot;BTC touches 100k&quot;, &quot;ETH at 4000&quot;</li>
+                <ul className="ml-5 mt-1 list-disc">
                   <li>
-                    Candle alerts: &quot;4H close above&quot;, &quot;Daily close below&quot;
+                    Price alerts: &quot;BTC touches 100k&quot;, &quot;ETH at
+                    4000&quot;
+                  </li>
+                  <li>
+                    Candle alerts: &quot;4H close above&quot;, &quot;Daily close
+                    below&quot;
                   </li>
                   <li>Shorthand: 100k = 100,000 | 94.2k = 94,200</li>
                 </ul>
@@ -150,7 +154,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
             <div className="space-y-4">
               {parsedAlerts.length > 0 && (
                 <>
-                  <div className="flex justify-between items-center">
+                  <div className="flex items-center justify-between">
                     <p className="text-gray-300">
                       Found {parsedAlerts.length} alerts.{" "}
                       {parsedAlerts.filter((a) => a.isValid).length} valid.
@@ -176,12 +180,12 @@ ETHBTC 4H close above 0.04 signals rotation`}
                     {parsedAlerts.map((alert) => (
                       <div
                         key={alert.id}
-                        className={`p-4 rounded-lg border ${
+                        className={`rounded-lg border p-4 ${
                           alert.isValid
                             ? selectedAlerts.has(alert.id)
-                              ? "bg-gray-800 border-blue-500"
-                              : "bg-gray-800/50 border-gray-700"
-                            : "bg-red-900/20 border-red-800/50"
+                              ? "border-blue-500 bg-gray-800"
+                              : "border-gray-700 bg-gray-800/50"
+                            : "border-red-800/50 bg-red-900/20"
                         }`}
                       >
                         <div className="flex items-start gap-3">
@@ -192,13 +196,13 @@ ETHBTC 4H close above 0.04 signals rotation`}
                             disabled={!alert.isValid}
                             className="mt-1 h-5 w-5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500"
                           />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2 flex-wrap">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
                               <span className="font-semibold text-white">
                                 {alert.pairSymbol ?? alert.coinSymbol}
                               </span>
                               <span
-                                className={`px-2 py-0.5 rounded text-xs font-medium ${
+                                className={`rounded px-2 py-0.5 text-xs font-medium ${
                                   alert.type === "CANDLE"
                                     ? "bg-purple-900/50 text-purple-300"
                                     : "bg-blue-900/50 text-blue-300"
@@ -212,7 +216,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
                               >
                                 {alert.direction}
                               </span>
-                              <span className="text-white font-mono">
+                              <span className="font-mono text-white">
                                 {parseFloat(alert.threshold).toLocaleString()}
                               </span>
                               <span
@@ -221,16 +225,16 @@ ETHBTC 4H close above 0.04 signals rotation`}
                                 ({alert.confidence})
                               </span>
                             </div>
-                            <p className="text-gray-400 text-sm mt-1 truncate">
+                            <p className="mt-1 truncate text-sm text-gray-400">
                               {alert.originalText}
                             </p>
                             {alert.notes && (
-                              <p className="text-gray-500 text-sm mt-1">
+                              <p className="mt-1 text-sm text-gray-500">
                                 💡 {alert.notes}
                               </p>
                             )}
                             {!alert.isValid && (
-                              <p className="text-red-400 text-sm mt-1">
+                              <p className="mt-1 text-sm text-red-400">
                                 ⚠️ {alert.validationError}
                               </p>
                             )}
@@ -243,11 +247,11 @@ ETHBTC 4H close above 0.04 signals rotation`}
               )}
 
               {unparseable.length > 0 && (
-                <div className="mt-4 p-4 bg-yellow-900/20 border border-yellow-800/50 rounded-lg">
-                  <p className="text-yellow-400 font-medium mb-2">
+                <div className="mt-4 rounded-lg border border-yellow-800/50 bg-yellow-900/20 p-4">
+                  <p className="mb-2 font-medium text-yellow-400">
                     Could not parse ({unparseable.length}):
                   </p>
-                  <ul className="text-gray-400 text-sm space-y-1">
+                  <ul className="space-y-1 text-sm text-gray-400">
                     {unparseable.map((line, i) => (
                       <li key={i} className="truncate">
                         • {line}
@@ -260,7 +264,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
           )}
 
           {step === "result" && (
-            <div className="text-center py-8">
+            <div className="py-8 text-center">
               {bulkCreate.isPending ? (
                 <div className="text-gray-300">Creating alerts...</div>
               ) : bulkCreate.data ? (
@@ -278,7 +282,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
                     )}
                   </div>
                   {bulkCreate.data.errors.length > 0 && (
-                    <div className="text-red-400 text-sm mt-4">
+                    <div className="mt-4 text-sm text-red-400">
                       {bulkCreate.data.errors.map((err, i) => (
                         <p key={i}>{err}</p>
                       ))}
@@ -291,7 +295,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-700 flex justify-end gap-3">
+        <div className="flex justify-end gap-3 border-t border-gray-700 px-6 py-4">
           {step === "input" && (
             <>
               <button
@@ -303,7 +307,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
               <button
                 onClick={handleParse}
                 disabled={!text.trim() || parseAlerts.isPending}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {parseAlerts.isPending ? "Parsing..." : "Parse Alerts"}
               </button>
@@ -321,7 +325,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
               <button
                 onClick={handleCreate}
                 disabled={selectedAlerts.size === 0 || bulkCreate.isPending}
-                className="px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                className="rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-500 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Create {selectedAlerts.size} Alerts
               </button>
@@ -331,7 +335,7 @@ ETHBTC 4H close above 0.04 signals rotation`}
           {step === "result" && (
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg"
+              className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-500"
             >
               Done
             </button>

--- a/src/app/alerts/components/AlertsPageWrapper.tsx
+++ b/src/app/alerts/components/AlertsPageWrapper.tsx
@@ -2,31 +2,57 @@
 
 import { useState } from "react";
 import { Button, Group } from "@mantine/core";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconFileImport } from "@tabler/icons-react";
 import { AlertModal } from "./AlertModal";
 import { AlertsList } from "./AlertsList";
+import { AlertImport } from "./AlertImport";
+import { api } from "~/trpc/react";
 
 export function AlertsPageWrapper() {
   const [modalOpened, setModalOpened] = useState(false);
+  const [importOpened, setImportOpened] = useState(false);
+  
+  const utils = api.useUtils();
 
   const openModal = () => setModalOpened(true);
   const closeModal = () => setModalOpened(false);
+  
+  const openImport = () => setImportOpened(true);
+  const closeImport = () => setImportOpened(false);
+  
+  const handleImportSuccess = () => {
+    // Refresh alerts list
+    void utils.alerts.getAllForUser.invalidate();
+  };
 
   return (
     <div className="space-y-6">
       <Group justify="space-between" align="center" mb="xl">
         <h1 className="text-2xl font-bold">Alerts</h1>
-        <Button
-          leftSection={<IconPlus size={16} />}
-          onClick={openModal}
-          radius="md"
-        >
-          Create Alert
-        </Button>
+        <Group gap="sm">
+          <Button
+            leftSection={<IconFileImport size={16} />}
+            onClick={openImport}
+            radius="md"
+            variant="outline"
+          >
+            Import from Text
+          </Button>
+          <Button
+            leftSection={<IconPlus size={16} />}
+            onClick={openModal}
+            radius="md"
+          >
+            Create Alert
+          </Button>
+        </Group>
       </Group>
 
       <AlertsList />
       <AlertModal opened={modalOpened} onClose={closeModal} />
+      {importOpened && (
+        <AlertImport onClose={closeImport} onSuccess={handleImportSuccess} />
+      )}
     </div>
   );
 }

--- a/src/app/alerts/components/AlertsPageWrapper.tsx
+++ b/src/app/alerts/components/AlertsPageWrapper.tsx
@@ -11,15 +11,15 @@ import { api } from "~/trpc/react";
 export function AlertsPageWrapper() {
   const [modalOpened, setModalOpened] = useState(false);
   const [importOpened, setImportOpened] = useState(false);
-  
+
   const utils = api.useUtils();
 
   const openModal = () => setModalOpened(true);
   const closeModal = () => setModalOpened(false);
-  
+
   const openImport = () => setImportOpened(true);
   const closeImport = () => setImportOpened(false);
-  
+
   const handleImportSuccess = () => {
     // Refresh alerts list
     void utils.alerts.getAllForUser.invalidate();


### PR DESCRIPTION
## Summary
Add a UI for the existing `parseAlerts` and `bulkCreate` APIs, allowing users to paste trading analysis text and automatically create alerts.

## Features
- **AI-powered parsing**: Uses GPT-4 to extract alerts from free-form text
- **Supported formats**:
  - Price alerts: "BTC touches 100k", "ETH at 4000"
  - Candle alerts: "4H close above", "Daily close below"
  - Shorthand: 100k = 100,000
- **Review step**: See all parsed alerts, their confidence levels, and validation status
- **Bulk creation**: Create multiple alerts at once

## Usage
1. Click "Import from Text" on the Alerts page
2. Paste your trading analysis
3. Review parsed alerts (select/deselect as needed)
4. Click "Create X Alerts"

## Screenshot
```
BTC 4H close ABOVE 100k confirms breakout  →  🟢 BTC/USDT CANDLE (4h) ABOVE 100,000 (high)
ETH price touches 4000                      →  🟢 ETH/USDT PRICE ABOVE 4,000 (high)
SOL BELOW 180 invalidates bullish           →  🟢 SOL/USDT PRICE BELOW 180 (high)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Import from Text" three-step flow (input, review, result) to import trading alerts with per-item selection, select all/none, validity/confidence/direction indicators, per-item errors, and a summary of created/failed alerts. The import action appears next to Create Alert and refreshes the alerts list on success.

* **Chores**
  * CI: linting/type-check steps updated to include environment configuration for those checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->